### PR TITLE
Started using Triangle.Net for mesh triangulation.

### DIFF
--- a/Assets/SpritesAndBones/Scripts/Skeleton.cs
+++ b/Assets/SpritesAndBones/Scripts/Skeleton.cs
@@ -406,7 +406,7 @@ public class Skeleton : MonoBehaviour {
 	{
 		//find all Skin2D elements
 		Skin2D[] skins = transform.GetComponentsInChildren<Skin2D>();
-		if(bones == null || bones.Length != null && bones.Length == 0) {
+		if(bones == null || bones.Length == 0) {
 			Debug.Log("No bones in skeleton");
 			return;
 		}

--- a/Assets/SpritesAndBones/Scripts/Triangulation/Triangle.NET/TriangleNetExtensions.cs
+++ b/Assets/SpritesAndBones/Scripts/Triangulation/Triangle.NET/TriangleNetExtensions.cs
@@ -1,0 +1,32 @@
+﻿using UnityEngine;
+using System.Collections;
+using TriangleNet;
+using TriangleNet.Geometry;
+using TriangleNet.Data;
+using System.Collections.Generic;
+
+public static class TriangleNetExtensions{
+    /// <summary> Inserts points and segments of the given polygon to the input geometry </summary>
+    static public void AddPolygon(this InputGeometry input, IList<Vector2> polygon){
+        int inputCount = input.Count;
+
+        input.AddPoint(polygon[0].x, polygon[0].y);
+        for(int i = 1, j = 0; i < polygon.Count; j = i++ ) {
+            input.AddPoint(polygon[i].x, polygon[i].y);
+            input.AddSegment(inputCount + j, inputCount + i);
+        }
+        input.AddSegment(input.Count - 1, inputCount);
+    }
+
+    /// <summary> Converts the triangle array returned from Triangle.Net to an index array for Unity Mesh triangles </summary>
+    static public int[] ToUnityMeshTriangleIndices(this ICollection<Triangle> triangles) {
+        int[] tris = new int[triangles.Count * 3];
+        int n = 0;
+        foreach(var t in triangles) {
+            tris[n++] = t.P1;
+            tris[n++] = t.P0;
+            tris[n++] = t.P2;
+        }
+        return tris;
+    }
+}


### PR DESCRIPTION
Previous triangulation algorithm caused triangles to use non-shared vertices. This would also cause mesh combining to not work. Now, mesh combining works (Subdivision aswell).

However, I can't understand the purpose of mesh combining in current context. If its purpose is to for example, combine different parts of a character into one mesh, a different approach like this is needed:
Instead of inputting mesh, a gameObject with mesh filter should be input and when combining mesh, transform of the object should be considered. Currently, it combines meshes to only overlap. (Can't explain clearly but you will understand when you try)